### PR TITLE
Added cbf param tvp

### DIFF
--- a/mpc_cbf.py
+++ b/mpc_cbf.py
@@ -67,6 +67,12 @@ class MPCCBF:
         _obs = model.set_variable(
             var_type='_tvp', var_name='obs', shape=(3, 1))
 
+        if self.robot_spec['model'] == 'Unicycle2D':
+            _alpha = model.set_variable(var_type='_tvp', var_name='alpha', shape=(1, 1))
+        elif self.robot_spec['model'] in ['DynamicUnicycle2D', 'DoubleIntegrator2D']:
+            _alpha1 = model.set_variable(var_type='_tvp', var_name='alpha1', shape=(1, 1))
+            _alpha2 = model.set_variable(var_type='_tvp', var_name='alpha2', shape=(1, 1))
+
         # System dynamics
         f_x = self.robot.f_casadi(_x)
         g_x = self.robot.g_casadi(_x)
@@ -140,6 +146,13 @@ class MPCCBF:
                     [self.goal+1000, [0]])
             else:
                 tvp_template['_tvp', :, 'obs'] = self.obs
+                
+            if self.robot_spec['model'] == 'Unicycle2D':
+                tvp_template['_tvp', :, 'alpha'] = self.cbf_param['alpha']
+            elif self.robot_spec['model'] in ['DynamicUnicycle2D', 'DoubleIntegrator2D']:
+                tvp_template['_tvp', :, 'alpha1'] = self.cbf_param['alpha1']
+                tvp_template['_tvp', :, 'alpha2'] = self.cbf_param['alpha2']
+                
             return tvp_template
 
         mpc.set_tvp_fun(tvp_fun)
@@ -162,13 +175,14 @@ class MPCCBF:
         We reuse this function to print the CBF constraint'''
 
         if self.robot_spec['model'] == 'Unicycle2D':
+            _alpha = self.model.tvp['alpha']
             h_k, d_h = self.robot.agent_barrier_dt(_x, _u, _obs)
-            cbf_constraint = d_h + self.cbf_param['alpha'] * h_k
+            cbf_constraint = d_h + _alpha * h_k
         elif self.robot_spec['model'] in ['DynamicUnicycle2D', 'DoubleIntegrator2D']:
+            _alpha1 = self.model.tvp['alpha1']
+            _alpha2 = self.model.tvp['alpha2']
             h_k, d_h, dd_h = self.robot.agent_barrier_dt(_x, _u, _obs)
-            cbf_constraint = dd_h + \
-                (self.cbf_param['alpha1'] + self.cbf_param['alpha2']) * d_h + \
-                self.cbf_param['alpha1'] * self.cbf_param['alpha2'] * h_k
+            cbf_constraint = dd_h + (_alpha1 + _alpha2) * d_h + _alpha1 * _alpha2 * h_k
         else:
             raise NotImplementedError('Model not implemented')
 


### PR DESCRIPTION
### Add TVP Parameters alpha, alpha1, and alpha2 for CBF Constraints


- Changed alpha, alpha1, and alpha2 as time-varying parameters (TVP) in the model.
- Updated set_tvp function to include these parameters.
- Modified compute_cbf_constraint to use TVP.
- This change allows CBF parameters to be updated dynamically during the simulation.